### PR TITLE
Send event on clear

### DIFF
--- a/vue-datepicker2.vue
+++ b/vue-datepicker2.vue
@@ -44,6 +44,9 @@ export default {
     $(this.$el).datepicker(options)
       .on('changeDate', (ev) => {
         this.$emit('change', ev.date);
+      })
+      .on('clearDate', () => {
+        this.$emit('change', null);
       });
 
     $(this.$el).datepicker('setDate', this.date);


### PR DESCRIPTION
This event is sent when the `Clear` button is pressed. It is needed to clear out the state that is bound to the `change` event. This seems to be the documentation for the element: https://bootstrap-datepicker.readthedocs.io/en/latest/events.html#cleardate