### PR TITLE
Check for initial date before setting

### DIFF
--- a/vue-datepicker2.vue
+++ b/vue-datepicker2.vue
@@ -49,7 +49,9 @@ export default {
         this.$emit('change', null);
       });
 
-    $(this.$el).datepicker('setDate', this.date);
+    if (this.date) {
+      $(this.$el).datepicker('setDate', this.date);
+    }
   },
 }
 </script>


### PR DESCRIPTION
Not setting an initial `date` prop results in:
```
TypeError: Cannot read properties of null (reading 'getTime')
```